### PR TITLE
allowing for multiple existingSecrets for vouch and change all parameters to camelCase

### DIFF
--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Run chart-testing (install)
         id: install
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args="--set=config.vouch.domains=example.com --set=config.vouch.whiteList=test@example.com" --helm-extra-args="--timeout 150s"
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-args="--timeout 150s"

--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Run chart-testing (install)
         id: install
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args="--set=bitwarden_eso_provider.create_cluster_secret_store=false --set=bitwarden_eso_provider.auth.password=${BOT_PASSWORD} --set=bitwarden_eso_provider.auth.clientID=${BOT_CLIENT_ID} --set=bitwarden_eso_provider.auth.clientSecret=${BOT_CLIENT_SECRET}"
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args="--set=bitwarden_eso_provider.create_cluster_secret_store=false --set=bitwarden_eso_provider.auth.password=${BOT_PASSWORD} --set=bitwarden_eso_provider.auth.clientID=${BOT_CLIENT_ID} --set=bitwarden_eso_provider.auth.clientSecret=${BOT_CLIENT_SECRET}" --helm-extra-args="--timeout 120s"

--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -43,13 +43,7 @@ jobs:
         uses: helm/kind-action@v1.8.0
         if: steps.list-changed.outputs.changed == 'true'
       
-      - name: Pull and side-load docker container
-        run: |
-          docker pull --platform=linux/amd64 docker.io/jessebot/bweso:v0.2.0 && \
-          kind load docker-image docker.io/jessebot/bweso:v0.2.0 --name chart-testing
-        shell: bash
-
       - name: Run chart-testing (install)
         id: install
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args="--set=bitwarden_eso_provider.create_cluster_secret_store=false --set=bitwarden_eso_provider.auth.password=${BOT_PASSWORD} --set=bitwarden_eso_provider.auth.clientID=${BOT_CLIENT_ID} --set=bitwarden_eso_provider.auth.clientSecret=${BOT_CLIENT_SECRET}" --helm-extra-args="--timeout 120s"
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args="--set=config.vouch.domains=example.com --set=config.vouch.whiteList=test@example.com" --helm-extra-args="--timeout 150s"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This is a fork of the official Vouch helm chart with some quality of life updates to match standard helm chart style. It's actively maintained and kept up to date by @jessebot and renovateBot, so if a new version of the Vouch docker image comes out, we'll automatically get a PR to update it :)
 
-## Usage
+# Usage
 
 Make sure you have helm installed. To get started with helm, read their [documentation](https://helm.sh/docs/).
 Here's the basics of running this chart, however you'll want to update your [`values.yaml`](./charts/vouch/values.yaml).
@@ -16,14 +16,100 @@ helm install vouch/vouch vouch --values.yaml
 
 Docs for the [`values.yaml`](./charts/vouch/values.yaml) can be found in in the chart [README](./charts/vouch/README.md).
 
-### Using an external secret
+## Using Existing Kubernetes Secrets for Private Info
 
-You can configure your values.yml for vouch to use an existing Kubernetes Secret for it's config file. Example `values.yaml`:
+### Existing Secret for the Oauth config
+
+In your values.yaml specify the name of the of the secret and then the names of the keys that will store the sensitive info:
 
 ```yaml
 config:
+  # https://console.developers.google.com/apis/credentials
+  oauth:
+    # -- existingSecret for clientId, clientSecret, authUrl, tokenUrl,userInfoUrl, callbackUrls, and preferredDomain. 
+    # If this value is not empty, we will ignore all of those plain text values and only use your secret keys
+    existingSecret: 'my-vouch-oauth-secret'
+    # keys in oauth.existingSecret to use for Oauth2 config
+    secretKeys:
+      # -- key in existingSecret for the clientID from your provider
+      clientId: 'clientId'
+      # -- key in existingSecret for clientSecret from your provider
+      clientSecret: 'clientSecret'
+      # -- key in existingSecret for authentication url from your oidc provider
+      authUrl: 'authUrl'
+      # -- key in existingSecret for token url from your oidc provider
+      tokenUrl: 'tokenUrl'
+      # -- key in existingSecret for userInfoUrl from your oidc provider
+      userInfoUrl: 'userInfoUrl'
+      # -- key in oauth.existingSecret for comma seperated list of valid
+      # callback urls to use, example value for your key in your existing secert:
+      # 'https://vouch.example.com/auth,https://vouch.example.com/login'
+      callbackUrls: 'callbackUrls'
+      # -- secret key in oauth.existingSecret for your preferred domain
+      preferredDomain: 'preferredDomain'
+```
+
+Example secret:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-vouch-oauth-secret
+# "stringData" doesn't have to be used, but if you use "data", you have to base64 encode the string values below
+stringData:
+  clientId: 'vouch'
+  clientSecret: '6f7dag78dagr4bcfydsuoivh9a8fh89'
+  authUrl: 'https://iam.example.com/realms/demo-realm/protocol/openid-connect/auth'
+  tokenUrl: 'https://iam.example.com/realms/master/protocol/openid-connect/token'
+  userInfoUrl: 'https://iam.example.com/realms/master/protocol/openid-connect/userinfo'
+  callbackUrls: 'https://vouch.example.com/auth'
+```
+
+
+### Existing Secret for vouch allowed domains and allowed emails
+
+In your values.yaml specify the name of the of the secret and then the names of the keys that will store the sensitive info:
+
+```yaml
+config:
+  vouch:
+    # -- existingSecret for domains, whiteList, and jwtSecret. If this value is
+    # not empty, we ignore vouch.domains, vouch.whiteList, and vouch.jwt.secret
+    existingSecret: 'my-vouch-config-secret'
+    # keys in vouch.existingSecret to use for vouch config
+    secretKeys:
+      # -- secret key in vouch.existingSecret with comma seperated list of
+      # domains you'd like to allow access from.
+      domains: 'domains'
+      # -- secret key in vouch.existingSecret with comma seperated list of emails
+      # for users that allowed to use SSO via vouch.
+      whiteList: 'whiteList'
+      # -- secret key in vouch.existingSecret to pass in a secret to used for cookies
+      jwtSecret: 'jwtSecret'
+```
+
+Make sure that `config.vouch.secretKeys.domains` and `config.vouch.secretKeys.whiteList` are both comma seperated lists.
+
+Example secret:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-vouch-config-secret
+# "stringData" doesn't have to be used, but if you use "data", you have to base64 encode the string values below
+stringData:
+  domains: "coolcats.com,cooldogs.com"
+  whiteList: "not-a-dog@gmail.com,cat@coolcats.com"
+```
+ 
+### Overriding the entire `config.yaml` for vouch-proxy
+You can configure your `values.yml` for vouch to use an existing Kubernetes Secret for it's *ENTIRE* config file. 
+
+Example `values.yaml`:
+```yaml
+config:
   # -- Allow overriding the config value with an existing secret, like a sealed secret
-  existingSecretName: "vouch-existing-secret"
+  overrideConfigExistingSecret: "vouch-existing-secret"
 ```
 
 Example of setting an existing Secret via the helm cli:

--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -17,15 +17,11 @@ keywords:
   - sso
   - sso-login
 
-version: 3.3.1
+version: 4.0.0
 
 # renovate: image=quay.io/vouch/vouch-proxy
 appVersion: "0.39"
 
 maintainers:
-  - name: punkle
-    email: brian@roadie.io
-  - name: halkeye
-    email: helm@gavinmogan.com
   - name: jessebot
     email: jessebot@linux.com

--- a/charts/vouch/README.md
+++ b/charts/vouch/README.md
@@ -40,7 +40,7 @@ An SSO and OAuth login solution for nginx using the auth_request module.
 | config.oauth.secretKeys.userInfoUrl | string | `"userInfoUrl"` | secret key in oauth.existingSecret for userInfoUrl from your oidc provider |
 | config.oauth.tokenUrl | string | `""` | token url from your oidc provider |
 | config.oauth.userInfoUrl | string | `""` | user info Url from your oidc provider |
-| config.overrideConfigExistingSecret | string | `""` | Allow overriding the ENTIRE config.yaml value with an existing secret,  like a sealed secret. If not empty string, ALL  values under config are ignored except for config.existing. For all possible config.yaml values, see: https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example |
+| config.overrideConfigExistingSecret | string | `""` | Allow overriding the ENTIRE config.yaml value with an existing secret, like a sealed secret. If not empty string, ALL  values under config are ignored except for config.existing. For all possible config.yaml values, see: https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example |
 | config.vouch.allowAllUsers | bool | `false` | whether or not to allow ALL users to login |
 | config.vouch.domains | list | `[]` | specific domains you'd like to allow access from |
 | config.vouch.existingSecret | string | `""` | existingSecret for domains, whiteList, and jwtSecret. If this value is not empty, we ignore vouch.domains, vouch.whiteList, and vouch.jwt.secret |

--- a/charts/vouch/README.md
+++ b/charts/vouch/README.md
@@ -42,7 +42,7 @@ An SSO and OAuth login solution for nginx using the auth_request module.
 | config.oauth.userInfoUrl | string | `""` | user info Url from your oidc provider |
 | config.overrideConfigExistingSecret | string | `""` | Allow overriding the ENTIRE config.yaml value with an existing secret, like a sealed secret. If not empty string, ALL  values under config are ignored except for config.existing. For all possible config.yaml values, see: https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example |
 | config.vouch.allowAllUsers | bool | `false` | whether or not to allow ALL users to login |
-| config.vouch.domains | list | `[]` | specific domains you'd like to allow access from |
+| config.vouch.domains | list | `[]` | array of specific domains you'd like to allow access from |
 | config.vouch.existingSecret | string | `""` | existingSecret for domains, whiteList, and jwtSecret. If this value is not empty, we ignore vouch.domains, vouch.whiteList, and vouch.jwt.secret |
 | config.vouch.jwt.secret | string | `""` | pass in a secret to used for cookies |
 | config.vouch.logLevel | string | `"debug"` | logging level for vouch |
@@ -51,7 +51,7 @@ An SSO and OAuth login solution for nginx using the auth_request module.
 | config.vouch.secretKeys.jwtSecret | string | `"jwtSecret"` | secret key in vouch.existingSecret to pass in a secret to used for cookies |
 | config.vouch.secretKeys.whiteList | string | `"whiteList"` | secret key in vouch.existingSecret with comma seperated list of emails for users that allowed to use SSO via vouch. Example secret value in your 'friend@coolcats.com,kitty@coolcats.com' |
 | config.vouch.testing | bool | `false` | if you enable this, it will    force all 302 redirects to be rendered as a webpage with a link |
-| config.vouch.whiteList | list | `[]` | list of emails for users that allowed to use SSO via vouch |
+| config.vouch.whiteList | list | `[]` | array of emails for users that allowed to use SSO via vouch |
 | deploymentAnnotations | object | `{}` |  |
 | extraEnvVars | list | `[]` | An array to add extra environment variables |
 | fullnameOverride | string | `""` |  |

--- a/charts/vouch/README.md
+++ b/charts/vouch/README.md
@@ -1,6 +1,6 @@
 # vouch
 
-![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.39](https://img.shields.io/badge/AppVersion-0.39-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.39](https://img.shields.io/badge/AppVersion-0.39-informational?style=flat-square)
 
 An SSO and OAuth login solution for nginx using the auth_request module.
 
@@ -10,8 +10,6 @@ An SSO and OAuth login solution for nginx using the auth_request module.
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| punkle | <brian@roadie.io> |  |
-| halkeye | <helm@gavinmogan.com> |  |
 | jessebot | <jessebot@linux.com> |  |
 
 ## Source Code
@@ -24,18 +22,35 @@ An SSO and OAuth login solution for nginx using the auth_request module.
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | args | list | `[]` | arguments to command for container |
-| command | list | `[]` | Allow to specify an alternate command before launching vouch example: command: ["/bin/sh", "-c", "source /vault/secrets/config && /vouch-proxy"] |
-| config.existingSecretName | string | `""` | Allow overriding the config value with an existing secret, like a sealed secret |
-| config.oauth.callback_urls | list | `[]` | valid callback urls to use, example https://vouch.example.com/auth |
-| config.oauth.client_id | string | `""` | clientID from  your provider |
-| config.oauth.client_secret | string | `""` | clientSecret from your provider |
+| command | list | `[]` | Allow to specify an alternate command before launching vouch example: command: ['/bin/sh', '-c', 'source /vault/secrets/config && /vouch-proxy'] |
+| config.oauth.authUrl | string | `""` | authentication url from your oidc provider |
+| config.oauth.callbackUrls | list | `[]` | valid callback urls to use, example https://vouch.example.com/auth |
+| config.oauth.clientId | string | `""` | clientID from  your provider |
+| config.oauth.clientSecret | string | `""` | clientSecret from your provider |
+| config.oauth.existingSecret | string | `""` | existingSecret for clientId, clientSecret, authUrl, tokenUrl, userInfoUrl, scopes, callbackUrls, and preferredDomain. If this value is not empty, we will ignore all of those plain text values and only use your secret keys |
 | config.oauth.preferredDomain | string | `""` | preferred domain |
 | config.oauth.provider | string | `""` | oauth2 provider, such as keycloak |
-| config.vouch.allowAllUsers | bool | `false` | wheather or not to allow ALL users to login |
+| config.oauth.scopes | list | `[]` | array of scopes to get from the provider e.g. [openid, email, profile] |
+| config.oauth.secretKeys.authUrl | string | `"authUrl"` | secret key in oauth.existingSecret for authentication url from your oidc provider |
+| config.oauth.secretKeys.callbackUrls | string | `"callbackUrls"` | secret key in oauth.existingSecret for commas seperated list of valid callback urls to use, example value for your key in your existing secert: 'https://vouch.example.com/auth,https://vouch.example.com/login' |
+| config.oauth.secretKeys.clientId | string | `"clientId"` | secret key in oauth.existingSecret for the clientID from your provider |
+| config.oauth.secretKeys.clientSecret | string | `"clientSecret"` | secret key in oauth.existingSecret for clientSecret from your provider |
+| config.oauth.secretKeys.preferredDomain | string | `"preferredDomain"` | secret key in oauth.existingSecret for your preferred domain |
+| config.oauth.secretKeys.tokenUrl | string | `"tokenUrl"` | secret key in oauth.existingSecret for token url from your oidc provider |
+| config.oauth.secretKeys.userInfoUrl | string | `"userInfoUrl"` | secret key in oauth.existingSecret for userInfoUrl from your oidc provider |
+| config.oauth.tokenUrl | string | `""` | token url from your oidc provider |
+| config.oauth.userInfoUrl | string | `""` | user info Url from your oidc provider |
+| config.overrideConfigExistingSecret | string | `""` | Allow overriding the ENTIRE config.yaml value with an existing secret,  like a sealed secret. If not empty string, ALL  values under config are ignored except for config.existing. For all possible config.yaml values, see: https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example |
+| config.vouch.allowAllUsers | bool | `false` | whether or not to allow ALL users to login |
 | config.vouch.domains | list | `[]` | specific domains you'd like to allow access from |
+| config.vouch.existingSecret | string | `""` | existingSecret for domains, whiteList, and jwtSecret. If this value is not empty, we ignore vouch.domains, vouch.whiteList, and vouch.jwt.secret |
 | config.vouch.jwt.secret | string | `""` | pass in a secret to used for cookies |
+| config.vouch.logLevel | string | `"debug"` | logging level for vouch |
 | config.vouch.port | int | `9090` | the container port for vouch |
-| config.vouch.testing | bool | `false` | set to true to enable a testing mode, see more: https://github.com/vouch/vouch-proxy#im-getting-an-infinite-redirect-loop-which-returns-me-to-my-idp-googleoktagithub |
+| config.vouch.secretKeys.domains | string | `"domains"` | secret key in vouch.existingSecret with comma seperated list of domains you'd like to allow access from. Example secret value in your existing secret: 'coolcats.com,cooldogs.com' |
+| config.vouch.secretKeys.jwtSecret | string | `"jwtSecret"` | secret key in vouch.existingSecret to pass in a secret to used for cookies |
+| config.vouch.secretKeys.whiteList | string | `"whiteList"` | secret key in vouch.existingSecret with comma seperated list of emails for users that allowed to use SSO via vouch. Example secret value in your 'friend@coolcats.com,kitty@coolcats.com' |
+| config.vouch.testing | bool | `false` | if you enable this, it will    force all 302 redirects to be rendered as a webpage with a link |
 | config.vouch.whiteList | list | `[]` | list of emails for users that allowed to use SSO via vouch |
 | deploymentAnnotations | object | `{}` |  |
 | extraEnvVars | list | `[]` | An array to add extra environment variables |

--- a/charts/vouch/templates/_helpers.tpl
+++ b/charts/vouch/templates/_helpers.tpl
@@ -1,4 +1,3 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/vouch/templates/_helpers.tpl
+++ b/charts/vouch/templates/_helpers.tpl
@@ -60,3 +60,32 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the secret to use for vouch config
+*/}}
+{{- define "vouch.config.secret.name" -}}
+{{- if .Values.config.overrideConfigExistingSecretName -}}
+{{- .Values.config.overrideConfigExistingSecretName -}}
+{{- else if .Values.config.vouch.existingSecret -}}
+{{- .Values.config.vouch.existingSecret -}}
+{{ template "vouch.fullname" . }}
+{{- else -}}
+
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Create the name of the secret to use for vouch oauth config
+*/}}
+{{- define "vouch.oauth.secret.name" -}}
+{{- if .Values.config.overrideConfigExistingSecretName -}}
+{{- .Values.config.overrideConfigExistingSecretName -}}
+{{- else if .Values.config.oauth.existingSecret -}}
+{{- .Values.config.oauth.existingSecret -}}
+{{- else -}}
+{{ template "vouch.fullname" . }}
+{{- end -}}
+{{- end -}}
+

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -60,12 +60,87 @@ spec:
             {{- toYaml .Values.args | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+          {{- if not .Values.config.overrideConfigExistingSecretName }}
             - name: VOUCH_PORT
               value: {{ .Values.config.vouch.port | quote }}
+            - name: VOUCH_LOGLEVEL
+              value: {{ .Values.config.vouch.logLevel | quote }}
+            - name: VOUCH_TESTING
+              value: {{ .Values.config.vouch.testing | quote }}
+            - name: VOUCH_ALLOWALLUSERS
+              value: {{ .Values.config.vouch.allowAllUsers }}
+            - name: VOUCH_DOMAINS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.vouch.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.vouch.secretKeys.domains }}
+            - name: VOUCH_WHITELIST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.vouch.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.vouch.secretKeys.whiteList }}
+            - name: VOUCH_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.vouch.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.vouch.secretKeys.jwtSecret }}
+            - name: OAUTH_PROVIDER
+              value: {{ .Values.config.oauth.provider }}
+            - name: OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.oauth.secretKeys.clientId }}
+            - name: OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.oauth.secretKeys.clientSecret }}
+            {{- if or .Values.config.oauth.authUrl (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.authUrl) }}
+            - name: OAUTH_AUTH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.oauth.secretKeys.authUrl }}
+            {{- end }}
+            {{- if or .Values.config.oauth.tokenUrl (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.tokenUrl) }}
+            - name: OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.oauth.secretKeys.tokenUrl }}
+            {{- end }}
+            {{- if or .Values.config.oauth.user_infoUrl (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.userInfoUrl) }}
+            - name: OAUTH_USER_INFO_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.oauth.secretKeys.userInfoUrl }}
+            {{- end }}
+            {{- if or .Values.config.oauth.callbackUrls (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.callbackUrls) }}
+            - name: OAUTH_CALLBACK_URLS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.oauth.secretKeys.callbackUrls }}
+            {{- end }}
+            - name: OAUTH_SCOPES
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}
+                  key: scopes
+            {{- if or .Values.config.oauth.preferredDomain (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.preferredDomain ) }}
+            - name: OAUTH_PREFERREDDOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  key: {{ .Values.config.oauth.secretKeys.preferredDomain }}
+            {{- end }}
             {{- range .Values.extraEnvVars }}
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.config.vouch.port }}
@@ -106,14 +181,18 @@ spec:
           volumeMounts:
           - name: data
             mountPath: /data
+          {{ if .Values.config.overrideConfigExistingSecretName }}
           - name: config
             mountPath: /config
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
+      {{ if .Values.config.overrideConfigExistingSecretName }}
       - name: config
         secret:
-          secretName: {{ if .Values.config.existingSecretName }}{{ .Values.config.existingSecretName }}{{- else }}{{ template "vouch.fullname" . }}{{- end }}
+          secretName: {{ .Values.config.overrideConfigExistingSecretName }}
+      {{- end }}
       - name: data
         emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -72,56 +72,56 @@ spec:
             - name: VOUCH_DOMAINS
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.vouch.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.config.secret.name" . }}
                   key: {{ .Values.config.vouch.secretKeys.domains }}
             - name: VOUCH_WHITELIST
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.vouch.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.config.secret.name" . }}
                   key: {{ .Values.config.vouch.secretKeys.whiteList }}
             - name: VOUCH_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.vouch.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.config.secret.name" . }}
                   key: {{ .Values.config.vouch.secretKeys.jwtSecret }}
             - name: OAUTH_PROVIDER
               value: {{ .Values.config.oauth.provider }}
             - name: OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.clientId }}
             - name: OAUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.clientSecret }}
             {{- if or .Values.config.oauth.authUrl (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.authUrl) }}
             - name: OAUTH_AUTH_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.authUrl }}
             {{- end }}
             {{- if or .Values.config.oauth.tokenUrl (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.tokenUrl) }}
             - name: OAUTH_TOKEN_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.tokenUrl }}
             {{- end }}
             {{- if or .Values.config.oauth.user_infoUrl (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.userInfoUrl) }}
             - name: OAUTH_USER_INFO_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.userInfoUrl }}
             {{- end }}
             {{- if or .Values.config.oauth.callbackUrls (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.callbackUrls) }}
             - name: OAUTH_CALLBACK_URLS
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.callbackUrls }}
             {{- end }}
             - name: OAUTH_SCOPES
@@ -133,7 +133,7 @@ spec:
             - name: OAUTH_PREFERREDDOMAIN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.oauth.existingSecret | default .Release.Name }}
+                  name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.preferredDomain }}
             {{- end }}
             {{- range .Values.extraEnvVars }}

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -69,33 +69,45 @@ spec:
               value: {{ .Values.config.vouch.testing | quote }}
             - name: VOUCH_ALLOWALLUSERS
               value: {{ .Values.config.vouch.allowAllUsers | quote }}
+            {{- if or .Values.config.vouch.domains (and .Values.config.vouch.existingSecret .Values.config.vouch.secretKeys.domains) }}
             - name: VOUCH_DOMAINS
               valueFrom:
                 secretKeyRef:
                   name: {{ template "vouch.config.secret.name" . }}
                   key: {{ .Values.config.vouch.secretKeys.domains }}
+            {{- end }}
+            {{- if or .Values.config.vouch.whiteList (and .Values.config.vouch.existingSecret .Values.config.vouch.secretKeys.whiteList) }}
             - name: VOUCH_WHITELIST
               valueFrom:
                 secretKeyRef:
                   name: {{ template "vouch.config.secret.name" . }}
                   key: {{ .Values.config.vouch.secretKeys.whiteList }}
+            {{- end }}
+            {{- if or .Values.config.vouch.jwt.secret (and .Values.config.vouch.existingSecret .Values.config.vouch.secretKeys.jwtSecret) }}
             - name: VOUCH_JWT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ template "vouch.config.secret.name" . }}
                   key: {{ .Values.config.vouch.secretKeys.jwtSecret }}
+            {{- end }}
+            {{- if .Values.config.oauth.provider }}
             - name: OAUTH_PROVIDER
               value: {{ .Values.config.oauth.provider }}
+            {{- end }}
+            {{- if or .Values.config.oauth.clientId (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.clientId)}}
             - name: OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.clientId }}
+            {{- end }}
+            {{- if or .Values.config.oauth.clientSecret (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.clientSecret)}}
             - name: OAUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.clientSecret }}
+            {{- end }}
             {{- if or .Values.config.oauth.authUrl (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.authUrl) }}
             - name: OAUTH_AUTH_URL
               valueFrom:
@@ -124,11 +136,13 @@ spec:
                   name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.callbackUrls }}
             {{- end }}
+            {{- if .Values.config.oauth.scopes }}
             - name: OAUTH_SCOPES
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}
                   key: scopes
+            {{- end }}
             {{- if or .Values.config.oauth.preferredDomain (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.preferredDomain ) }}
             - name: OAUTH_PREFERREDDOMAIN
               valueFrom:

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -122,7 +122,7 @@ spec:
                   name: {{ template "vouch.oauth.secret.name" . }}
                   key: {{ .Values.config.oauth.secretKeys.tokenUrl }}
             {{- end }}
-            {{- if or .Values.config.oauth.user_infoUrl (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.userInfoUrl) }}
+            {{- if or .Values.config.oauth.userInfoUrl (and .Values.config.oauth.existingSecret .Values.config.oauth.secretKeys.userInfoUrl) }}
             - name: OAUTH_USER_INFO_URL
               valueFrom:
                 secretKeyRef:

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - name: VOUCH_TESTING
               value: {{ .Values.config.vouch.testing | quote }}
             - name: VOUCH_ALLOWALLUSERS
-              value: {{ .Values.config.vouch.allowAllUsers }}
+              value: {{ .Values.config.vouch.allowAllUsers | quote }}
             - name: VOUCH_DOMAINS
               valueFrom:
                 secretKeyRef:

--- a/charts/vouch/templates/secret.yaml
+++ b/charts/vouch/templates/secret.yaml
@@ -9,29 +9,19 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
-  {{- if and .Values.config.vouch.domains (not .Values.config.vouch.existingSecret) }}
+  {{- if not .Values.config.vouch.existingSecret }}
   domains: {{ join "," .Values.config.vouch.domains | b64enc | quote }}
   whiteList: {{ join "," .Values.config.vouch.whiteList | b64enc | quote }}
-  {{- if .Values.config.vouch.jwt.secret }}
   jwtSecret: {{ .Values.config.vouch.jwt.secret | b64enc | quote }}
   {{- end }}
-  {{- end }}
-  {{- if and .Values.config.oauth (not .Values.config.oauth.existingSecret) }}
+  {{- if not .Values.config.oauth.existingSecret }}
   provider: {{ .Values.config.oauth.provider | b64enc | quote }}
   clientId: {{ .Values.config.oauth.clientId | b64enc | quote }}
   clientSecret: {{ .Values.config.oauth.clientSecret | b64enc | quote }}
-  {{- if .Values.config.oauth.authUrl }}
   authUrl: {{ .Values.config.oauth.authUrl | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.config.oauth.tokenUrl }}
   tokenUrl: {{ .Values.config.oauth.tokenUrl | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.config.oauth.userInfoUrl }}
   userInfoUrl: {{ .Values.config.oauth.userInfoUrl | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.config.oauth.callbackUrls }}
   callbackUrls: {{ join "," .Values.config.oauth.callbackUrls | b64enc | quote }}
-  {{- end }}
   preferredDomain: {{ .Values.config.oauth.preferredDomain | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/vouch/templates/secret.yaml
+++ b/charts/vouch/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.config.existingSecretName }}
+{{- if not .Values.config.overrideConfigExistingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,45 +8,30 @@ metadata:
     helm.sh/chart: {{ include "vouch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-stringData:
-  config.yaml: |
-    {{- if .Values.config.vouch }}
-    vouch:
-      port: {{ .Values.config.vouch.port }}
-      logLevel: {{ .Values.config.vouch.logLevel }}
-      testing: {{ .Values.config.vouch.testing }}
-      domains:
-      {{ toYaml .Values.config.vouch.domains | indent 8 }}
-      whiteList:
-      {{ toYaml .Values.config.vouch.whiteList| indent 8 }}
-      allowAllUsers: {{ .Values.config.vouch.allowAllUsers }}
-      {{- if .Values.config.vouch.jwt.secret }}
-      jwt:
-        secret: {{ .Values.config.vouch.jwt.secret }}
-      {{- end }}
-    {{- end }}
-    {{- if .Values.config.oauth }}
-    oauth:
-      provider: {{ .Values.config.oauth.provider }}
-      client_id: {{ .Values.config.oauth.clientId }}
-      client_secret: {{ .Values.config.oauth.clientSecret }}
-      {{- if .Values.config.oauth.authUrl }}
-      auth_url: {{ .Values.config.oauth.authUrl }}
-      {{- end }}
-      {{- if .Values.config.oauth.tokenUrl }}
-      token_url: {{ .Values.config.oauth.tokenUrl }}
-      {{- end }}
-      {{- if .Values.config.oauth.userInfoUrl }}
-      user_info_url: {{ .Values.config.oauth.userInfoUrl }}
-      {{- end }}
-      {{- if .Values.config.oauth.scopes }}
-      scopes:
-      {{ toYaml .Values.config.oauth.scopes | indent 8 }}
-      {{- end }}
-      {{- if .Values.config.oauth.callbackUrls }}
-      callback_urls:
-      {{ toYaml .Values.config.oauth.callbackUrls | indent 8 }}
-      {{- end }}
-      preferredDomain: {{ .Values.config.oauth.preferredDomain }}
-    {{- end }}
+data:
+  {{- if and .Values.config.vouch.domains (not .Values.config.vouch.existingSecret) }}
+  domains: {{ join "," .Values.config.vouch.domains | b64enc | quote }}
+  whiteList: {{ join "," .Values.config.vouch.whiteList | b64enc | quote }}
+  {{- if .Values.config.vouch.jwt.secret }}
+  jwtSecret: {{ .Values.config.vouch.jwt.secret | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if and .Values.config.oauth (not .Values.config.oauth.existingSecret) }}
+  provider: {{ .Values.config.oauth.provider | b64enc | quote }}
+  clientId: {{ .Values.config.oauth.clientId | b64enc | quote }}
+  clientSecret: {{ .Values.config.oauth.clientSecret | b64enc | quote }}
+  {{- if .Values.config.oauth.authUrl }}
+  authUrl: {{ .Values.config.oauth.authUrl | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.config.oauth.tokenUrl }}
+  tokenUrl: {{ .Values.config.oauth.tokenUrl | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.config.oauth.userInfoUrl }}
+  userInfoUrl: {{ .Values.config.oauth.userInfoUrl | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.config.oauth.callbackUrls }}
+  callbackUrls: {{ join "," .Values.config.oauth.callbackUrls | b64enc | quote }}
+  {{- end }}
+  preferredDomain: {{ .Values.config.oauth.preferredDomain | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/vouch/templates/secret.yaml
+++ b/charts/vouch/templates/secret.yaml
@@ -10,12 +10,43 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 stringData:
   config.yaml: |
-{{- if .Values.config.vouch }}
+    {{- if .Values.config.vouch }}
     vouch:
-{{ toYaml .Values.config.vouch | indent 6 }}
-{{- end }}
-{{- if .Values.config.oauth }}
+      port: {{ .Values.config.vouch.port }}
+      logLevel: {{ .Values.config.vouch.logLevel }}
+      testing: {{ .Values.config.vouch.testing }}
+      domains:
+      {{ toYaml .Values.config.vouch.domains | indent 8 }}
+      whiteList:
+      {{ toYaml .Values.config.vouch.whiteList| indent 8 }}
+      allowAllUsers: {{ .Values.config.vouch.allowAllUsers }}
+      {{- if .Values.config.vouch.jwt.secret }}
+      jwt:
+        secret: {{ .Values.config.vouch.jwt.secret }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.config.oauth }}
     oauth:
-{{ toYaml .Values.config.oauth | indent 6 }}
-{{- end }}
+      provider: {{ .Values.config.oauth.provider }}
+      client_id: {{ .Values.config.oauth.clientId }}
+      client_secret: {{ .Values.config.oauth.clientSecret }}
+      {{- if .Values.config.oauth.authUrl }}
+      auth_url: {{ .Values.config.oauth.authUrl }}
+      {{- end }}
+      {{- if .Values.config.oauth.tokenUrl }}
+      token_url: {{ .Values.config.oauth.tokenUrl }}
+      {{- end }}
+      {{- if .Values.config.oauth.userInfoUrl }}
+      user_info_url: {{ .Values.config.oauth.userInfoUrl }}
+      {{- end }}
+      {{- if .Values.config.oauth.scopes }}
+      scopes:
+      {{ toYaml .Values.config.oauth.scopes | indent 8 }}
+      {{- end }}
+      {{- if .Values.config.oauth.callbackUrls }}
+      callback_urls:
+      {{ toYaml .Values.config.oauth.callbackUrls | indent 8 }}
+      {{- end }}
+      preferredDomain: {{ .Values.config.oauth.preferredDomain }}
+    {{- end }}
 {{- end }}

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -124,9 +124,9 @@ config:
     testing: false
     # -- the container port for vouch
     port: 9090
-    # -- specific domains you'd like to allow access from
+    # -- array of specific domains you'd like to allow access from
     domains: []
-    # -- list of emails for users that allowed to use SSO via vouch
+    # -- array of emails for users that allowed to use SSO via vouch
     whiteList: []
     # -- whether or not to allow ALL users to login
     allowAllUsers: false

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -111,7 +111,7 @@ deploymentAnnotations: {}
 # bare minimum to get vouch running with google
 
 config:
-  # -- Allow overriding the ENTIRE config.yaml value with an existing secret, 
+  # -- Allow overriding the ENTIRE config.yaml value with an existing secret,
   # like a sealed secret. If not empty string, ALL  values under config are ignored
   # except for config.existing. For all possible config.yaml values, see:
   # https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -8,19 +8,19 @@ replicaCount: 1
 image:
   repository: quay.io/vouch/vouch-proxy
   # -- change the tag we use for the vouch docker image
-  tag: ""
+  tag: ''
   # -- image pullPolicy, set to always if using an image with the latest tag
   pullPolicy: IfNotPresent
 
 # -- Allow to specify an alternate command before launching vouch
-# example: command: ["/bin/sh", "-c", "source /vault/secrets/config && /vouch-proxy"]
+# example: command: ['/bin/sh', '-c', 'source /vault/secrets/config && /vouch-proxy']
 command: []
 # -- arguments to command for container
 args: []
 
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 serviceAccount:
   # -- Specifies whether a service account should be created
@@ -76,8 +76,8 @@ ingress:
   enabled: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  paths: ["/"]
+    # kubernetes.io/tls-acme: 'true'
+  paths: ['/']
   hosts:
     - chart-example.local
   tls: []
@@ -111,39 +111,90 @@ deploymentAnnotations: {}
 # bare minimum to get vouch running with google
 
 config:
-  # -- Allow overriding the config value with an existing secret, like a sealed secret
-  existingSecretName: ""
+  # -- Allow overriding the ENTIRE config.yaml value with an existing secret, 
+  # like a sealed secret. If not empty string, ALL  values under config are ignored
+  # except for config.existing. For all possible config.yaml values, see:
+  # https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example
+  overrideConfigExistingSecret: ''
 
   vouch:
+    # --  logging level for vouch
+    logLevel: debug
+    # -- if you enable this, it will    force all 302 redirects to be rendered as a webpage with a link
+    testing: false
     # -- the container port for vouch
     port: 9090
     # -- specific domains you'd like to allow access from
     domains: []
-    # -- wheather or not to allow ALL users to login
-    allowAllUsers: false
     # -- list of emails for users that allowed to use SSO via vouch
     whiteList: []
+    # -- whether or not to allow ALL users to login
+    allowAllUsers: false
     jwt:
       # -- pass in a secret to used for cookies
       secret: ''
-    # -- set to true to enable a testing mode, see more: https://github.com/vouch/vouch-proxy#im-getting-an-infinite-redirect-loop-which-returns-me-to-my-idp-googleoktagithub
-    testing: false
+    # -- existingSecret for domains, whiteList, and jwtSecret. If this value is
+    # not empty, we ignore vouch.domains, vouch.whiteList, and vouch.jwt.secret
+    existingSecret: ''
+    # keys in vouch.existingSecret to use for vouch config
+    secretKeys:
+      # -- secret key in vouch.existingSecret with comma seperated list of
+      # domains you'd like to allow access from. Example secret value in your
+      # existing secret: 'coolcats.com,cooldogs.com'
+      domains: 'domains'
+      # -- secret key in vouch.existingSecret with comma seperated list of emails
+      # for users that allowed to use SSO via vouch. Example secret value in your
+      # 'friend@coolcats.com,kitty@coolcats.com'
+      whiteList: 'whiteList'
+      # -- secret key in vouch.existingSecret to pass in a secret to used for cookies
+      jwtSecret: 'jwtSecret'
 
   # https://console.developers.google.com/apis/credentials
   oauth:
     # -- oauth2 provider, such as keycloak
-    provider: ""
+    provider: ''
     # -- clientID from  your provider
-    client_id: ""
+    clientId: ''
     # -- clientSecret from your provider
-    client_secret: ""
+    clientSecret: ''
+    # -- authentication url from your oidc provider
+    authUrl: ''
+    # -- token url from your oidc provider
+    tokenUrl: ''
+    # -- user info Url from your oidc provider
+    userInfoUrl: ''
+    # -- array of scopes to get from the provider e.g. [openid, email, profile]
+    scopes: []
     # -- valid callback urls to use, example https://vouch.example.com/auth
-    callback_urls: []
+    callbackUrls: []
     # -- preferred domain
-    preferredDomain: ""
+    preferredDomain: ''
+    # -- existingSecret for clientId, clientSecret, authUrl, tokenUrl,
+    # userInfoUrl, scopes, callbackUrls, and preferredDomain. If this value
+    # is not empty, we will ignore all of those plain text values and only use
+    # your secret keys
+    existingSecret: ''
+    # keys in oauth.existingSecret to use for Oauth2 config
+    secretKeys:
+      # -- secret key in oauth.existingSecret for the clientID from your provider
+      clientId: 'clientId'
+      # -- secret key in oauth.existingSecret for clientSecret from your provider
+      clientSecret: 'clientSecret'
+      # -- secret key in oauth.existingSecret for authentication url from your oidc provider
+      authUrl: 'authUrl'
+      # -- secret key in oauth.existingSecret for token url from your oidc provider
+      tokenUrl: 'tokenUrl'
+      # -- secret key in oauth.existingSecret for userInfoUrl from your oidc provider
+      userInfoUrl: 'userInfoUrl'
+      # -- secret key in oauth.existingSecret for commas seperated list of valid
+      # callback urls to use, example value for your key in your existing secert:
+      # 'https://vouch.example.com/auth,https://vouch.example.com/login'
+      callbackUrls: 'callbackUrls'
+      # -- secret key in oauth.existingSecret for your preferred domain
+      preferredDomain: 'preferredDomain'
 
 # -- An array to add extra environment variables
 extraEnvVars: []
 # Example:
 #   - name: HTTPS_PROXY
-#     value: "https://example.com"
+#     value: 'https://example.com'


### PR DESCRIPTION
You can now specify a seperate secret for both oauth and vouch domains/emails. Both use specific keys in the secret instead of overwriting the entire vouch config, though you can still do that too, though the parameter for that has changed from `config.existingSecretName` to `config.overrideConfigExistingSecretName`. More details below:

## Using Existing Kubernetes Secrets for Private Info

### Existing Secret for the Oauth config

In your values.yaml specify the name of the of the secret and then the names of the keys that will store the sensitive info:

```yaml
config:
  # https://console.developers.google.com/apis/credentials
  oauth:
    # -- existingSecret for clientId, clientSecret, authUrl, tokenUrl,userInfoUrl, callbackUrls, and preferredDomain.
    # If this value is not empty, we will ignore all of those plain text values and only use your secret keys
    existingSecret: 'my-vouch-oauth-secret'
    # keys in oauth.existingSecret to use for Oauth2 config
    secretKeys:
      # -- key in existingSecret for the clientID from your provider
      clientId: 'clientId'
      # -- key in existingSecret for clientSecret from your provider
      clientSecret: 'clientSecret'
      # -- key in existingSecret for authentication url from your oidc provider
      authUrl: 'authUrl'
      # -- key in existingSecret for token url from your oidc provider
      tokenUrl: 'tokenUrl'
      # -- key in existingSecret for userInfoUrl from your oidc provider
      userInfoUrl: 'userInfoUrl'
      # -- key in oauth.existingSecret for comma seperated list of valid
      # callback urls to use, example value for your key in your existing secert:
      # 'https://vouch.example.com/auth,https://vouch.example.com/login'
      callbackUrls: 'callbackUrls'
      # -- secret key in oauth.existingSecret for your preferred domain
      preferredDomain: 'preferredDomain'
```

Example secret:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: my-vouch-oauth-secret
# "stringData" doesn't have to be used, but if you use "data", you have to base64 encode the string values below
stringData:
  clientId: 'vouch'
  clientSecret: '6f7dag78dagr4bcfydsuoivh9a8fh89'
  authUrl: 'https://iam.example.com/realms/demo-realm/protocol/openid-connect/auth'
  tokenUrl: 'https://iam.example.com/realms/master/protocol/openid-connect/token'
  userInfoUrl: 'https://iam.example.com/realms/master/protocol/openid-connect/userinfo'
  callbackUrls: 'https://vouch.example.com/auth'
```


### Existing Secret for vouch allowed domains and allowed emails

In your values.yaml specify the name of the of the secret and then the names of the keys that will store the sensitive info:

```yaml
config:
  vouch:
    # -- existingSecret for domains, whiteList, and jwtSecret. If this value is
    # not empty, we ignore vouch.domains, vouch.whiteList, and vouch.jwt.secret
    existingSecret: 'my-vouch-config-secret'
    # keys in vouch.existingSecret to use for vouch config
    secretKeys:
      # -- secret key in vouch.existingSecret with comma seperated list of
      # domains you'd like to allow access from.
      domains: 'domains'
      # -- secret key in vouch.existingSecret with comma seperated list of emails
      # for users that allowed to use SSO via vouch.
      whiteList: 'whiteList'
      # -- secret key in vouch.existingSecret to pass in a secret to used for cookies
      jwtSecret: 'jwtSecret'
```

Make sure that `config.vouch.secretKeys.domains` and `config.vouch.secretKeys.whiteList` are both comma seperated lists.

Example secret:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: my-vouch-config-secret
# "stringData" doesn't have to be used, but if you use "data", you have to base64 encode the string values below
stringData:
  domains: "coolcats.com,cooldogs.com"
  whiteList: "not-a-dog@gmail.com,cat@coolcats.com"
```

### Overriding the entire `config.yaml` for vouch-proxy
You can configure your `values.yml` for vouch to use an existing Kubernetes Secret for it's *ENTIRE* config file.

Example `values.yaml`:
```yaml
config:
  # -- Allow overriding the config value with an existing secret, like a sealed secret
  overrideConfigExistingSecret: "vouch-existing-secret"
```

Example of setting an existing Secret via the helm cli:

```console
helm install vouch/vouch vouch --set existingSecretName=vouch-existing-secret
```

Here's a Kubernetes Secret containing a Vouch config that uses keycloak as the OIDC provider:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: vouch-existing-secret
stringData:
  config.yaml: |
    vouch:
      logLevel: debug
      testing: false
      domains:
      - example.com
      whiteList:
      - myuser@myemaildomain.com
      allowAllUsers: false
      cookie:
        maxAge: 900
        secure: true
        domain: example.com
    oauth:
      provider: oidc
      client_id: vouch
      client_secret: 8943hncds9aavy89hn39ncdsa89y79vh79as
      auth_url: https://iam.example.com/realms/master/protocol/openid-connect/auth
      token_url: https://iam.example.com/realms/master/protocol/openid-connect/token
      user_info_url: https://iam.example.com/realms/master/protocol/openid-connect/userinfo
      scopes:
        - openid
        - email
        - profile
      callback_urls:
        - https://vouch.example.com/auth
      preferredDomain:
```